### PR TITLE
Add navigational breadcrumbs

### DIFF
--- a/code/css/README.md
+++ b/code/css/README.md
@@ -1,3 +1,6 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md)
+
 # CSS
 
 ## Syntax

--- a/code/git/Branches.md
+++ b/code/git/Branches.md
@@ -1,3 +1,7 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md) >
+[Git](./README.md)
+
 # Branches
 
 - Never delete a remote branch with unmerged commits without asking the author

--- a/code/git/Commit-Messages.md
+++ b/code/git/Commit-Messages.md
@@ -1,3 +1,7 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md) >
+[Git](./README.md)
+
 # Commit Messages
 
 Good commit messages provide invaluable context when one is attempting to

--- a/code/git/Merging.md
+++ b/code/git/Merging.md
@@ -1,3 +1,7 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md) >
+[Git](./README.md)
+
 # Merging
 
 If you need to merge `master` into a shared feature branch (sometimes referred

--- a/code/git/README.md
+++ b/code/git/README.md
@@ -1,3 +1,6 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md)
+
 # Git
 
 Use [this](./.gitmessage) `.gitmessage` template for commits.

--- a/code/git/Style.md
+++ b/code/git/Style.md
@@ -1,3 +1,7 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md) >
+[Git](./README.md)
+
 # Style
 
 - Create commits as needed while working, but before merging to master, squash

--- a/code/javascript/README.md
+++ b/code/javascript/README.md
@@ -1,3 +1,6 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md)
+
 # JavaScript Style Guide
 
 When in doubt refer to the [eslint-config-coverhound](https://github.com/coverhound/eslint-config-coverhound) repo.

--- a/code/ruby/README.md
+++ b/code/ruby/README.md
@@ -1,3 +1,6 @@
+[Main](../../README.md) >
+[Technical Guidelines and Style](../README.md)
+
 # Ruby
 
 When in doubt, refer to the [`.rubocop.yml`](./.rubocop.yml)

--- a/people/Being-Human.md
+++ b/people/Being-Human.md
@@ -1,3 +1,6 @@
+[Main](../README.md) >
+[People](./README.md)
+
 # Being Human
 
 - Use people's chosen personal pronoun.

--- a/people/Communication.md
+++ b/people/Communication.md
@@ -1,3 +1,6 @@
+[Main](../README.md) >
+[People](./README.md)
+
 # Core Hours: 10:30AM – 3:30PM
 
 Core hours consist of hours during which all employees are expected to be

--- a/people/Meetings.md
+++ b/people/Meetings.md
@@ -1,3 +1,6 @@
+[Main](../README.md) >
+[People](./README.md)
+
 # Meetings
 
 ## Standup

--- a/people/Onboarding.md
+++ b/people/Onboarding.md
@@ -1,3 +1,6 @@
+[Main](../README.md) >
+[People](./README.md)
+
 # Onboarding
 
 Each new engineer should be assigned an onboarding buddy to answer their

--- a/people/README.md
+++ b/people/README.md
@@ -1,3 +1,5 @@
+[Main](../README.md)
+
 # People
 
 + [Being Human](./Being-Human.md)

--- a/people/Teamwork/Conflict.md
+++ b/people/Teamwork/Conflict.md
@@ -1,3 +1,7 @@
+[Main](../../README.md) >
+[People](../README.md) >
+[Teamwork](./README.md)
+
 # Conflict
 
 If you have a conflict with someone, try to resolve it tactfully.

--- a/people/Teamwork/README.md
+++ b/people/Teamwork/README.md
@@ -1,3 +1,6 @@
+[Main](../../README.md) >
+[People](../README.md)
+
 # Teamwork
 
 - In team discussions, respectful expression of dissenting opinions is encouraged.

--- a/process/Code-Review/Adding-Dependencies.md
+++ b/process/Code-Review/Adding-Dependencies.md
@@ -1,3 +1,7 @@
+[Main](../../README.md) >
+[Process](../README.md) >
+[Code Review](./README.md)
+
 # Adding Dependencies
 
 When adding dependencies, we should consider downstream effects. It should be in

--- a/process/Code-Review/README.md
+++ b/process/Code-Review/README.md
@@ -1,3 +1,6 @@
+[Main](../../README.md) >
+[Process](../README.md) >
+
 # Code Review
 
 This section is about reviewing code that has been committed and pushed to

--- a/process/Issue-Tracking.md
+++ b/process/Issue-Tracking.md
@@ -1,3 +1,6 @@
+[Main](../README.md) >
+[Process](./README.md)
+
 # Issue Tracking
 
 ## The Cycle

--- a/process/Learning-Time.md
+++ b/process/Learning-Time.md
@@ -1,3 +1,6 @@
+[Main](../README.md) >
+[Process](./README.md)
+
 # Learning Time
 
 This is explicit time invested in developing your skills or working on something

--- a/process/README.md
+++ b/process/README.md
@@ -1,3 +1,5 @@
+[Main](../README.md)
+
 # Process
 
 + [Code Review](./Code-Review/README.md)

--- a/process/Settings.md
+++ b/process/Settings.md
@@ -1,3 +1,6 @@
+[Main](../README.md) >
+[Process](./README.md)
+
 # Settings
 
 ## Configuration Files and the Settings Repo


### PR DESCRIPTION
This should make the document much easier to navigate. When presented on
Github pages, the directory listings cannot be accessed. Anything we can
do for accessibility is a good thing.