### PR TITLE
Clean up conflict section

### DIFF
--- a/people/Teamwork/Conflict.md
+++ b/people/Teamwork/Conflict.md
@@ -2,26 +2,31 @@
 
 If you have a conflict with someone, try to resolve it tactfully.
 
-#### Principles
+## Principles
 - Keep issues between yourselves or bring in a manager's help if needed.
-  - Example: message the person "Hey, why did you close my PR?"
-rather than saying in Slack or in a meeting, "It'd be nice if people wouldn't
-close other people's PRs without telling them." (Hypothetical situation.)
-- Mention circumstances and how they impact you, rather than attacking others' character
-  - Example: tell someone "I felt sort of attacked by the thing you said in that PR", rather than, "Hey! Why are you always attacking me, you jerk?"
-- Assume good will and be grateful to others when they bring an issue to your attention
+  - Example: message the person "Hey, why did you close my pull request?" rather
+    than saying in Slack or in a meeting, "It'd be nice if people wouldn't close
+    other people's pull requests without telling them." (Hypothetical
+    situation.)
+- Mention circumstances and how they impact you, rather than attacking others'
+  character
+  - Example: tell someone "I felt sort of attacked by the thing you said in that
+    pull request", rather than, "Hey! Why are you always attacking me, you
+    jerk?"
+- Assume good will and be grateful to others when they bring an issue to your
+  attention
 - Apologize for your mistakes as needed
 
-#### Asking For Help
+## Asking For Help
 
 When attempting to resolve conflicts, it can sometimes be very helpful to have
 someone else there to help. A dedicated mediator is a well-established concept
 in conflict resolution. We would be wise to use this concept as well.
 
-##### Who Can Help
+## Who Can Help
 
 Anyone can be a mediator. An authority figure can sometimes be helpful, but is
-defnitely not required. In terms of who to ask, here are some suggestions:
+definitely not required. In terms of who to ask, here are some suggestions:
 + Your tech lead
   + Your tech lead is invested in unblocking you. Conflicts are blockers.
 + Your manager
@@ -33,7 +38,7 @@ defnitely not required. In terms of who to ask, here are some suggestions:
   + Another engineer from your team (but separate from the conflict) or from
     another team can be a great help to resolve conflict.
 
-##### How To Ask For Help
+## How To Ask For Help
 
 It can be hard to ask for help. If that is the case for you, feel free to use
 any of these phrases to get the conversation started.


### PR DESCRIPTION
There are a few clean ups here:
+ Fix misspellings
+ Resolve headings relative to the main page topic as an H1
    + i.e. All child topics should be H2s and they're children would be
      H3s, etc.
+ Prefer fully qualified terms over initialisms
    + "Pull request" over "PR"
+ Wrap source at 80 characters