### PR TITLE
Prefer clarity over concision

### DIFF
--- a/code/git/Branches.md
+++ b/code/git/Branches.md
@@ -6,8 +6,8 @@
 
 - Never delete a remote branch with unmerged commits without asking the author
   first.
-- Never merge a PR when the branch being merged to is red on Solano UNLESS the
-  purpose of the PR is to fix the test.
+- Never merge a pull request when the branch being merged to is red on Solano
+  UNLESS the purpose of the pull request is to fix the test.
 - Don't force push to a shared branch without approval from all involved.
 - Prefix all your branch names with your initials or username. This helps
   prevent name collisions.
@@ -16,10 +16,12 @@
 - Remove branches that have been merged or not necessary for reference from
   GitHub.
 - If your branch has a merge conflict with master, prefer rebasing on master to
-  merging, with the following caveats (in either case see [Merging](./Merging.md)):
+  merging, with the following caveats (in either case see
+  [Merging](./Merging.md)):
   - You must merge if the branch is a shared feature branch.
   - If there are complex conflicts to be resolved, merging may make it clearer
     to resolve these.
 - When a team is using a feature branch to collaborate on larger pieces of work,
   the feature branch must be protected.
-    - Branch protection settings are addressed [in the wiki](https://github.com/coverhound/wiki/blob/master/ci/feature-branches.md).
+    - Branch protection settings are addressed [in the
+      wiki](https://github.com/coverhound/wiki/blob/master/ci/feature-branches.md).

--- a/code/git/Merging.md
+++ b/code/git/Merging.md
@@ -5,8 +5,9 @@
 # Merging
 
 If you need to merge `master` into a shared feature branch (sometimes referred
-to as "watering" your branch with `master`) then you need to open a PR to do
-that. If there are no conflicts then that PR can be merged without difficulty.
+to as "watering" your branch with `master`) then you need to open a pull request
+to do that. If there are no conflicts then that pull request can be merged
+without difficulty.
 
 ## Merge Conflicts
 
@@ -22,11 +23,18 @@ conflicts:
     - Optional: Some folks may prefer to uncomment the conflicting files in the
       commit message, that's okay, but not required.
 3. Fix conflicts in the files you noted and make a single new commit with all
-   the fixes.
-4. Put up a PR for merging this branch into master and go through the normal PR
-   review process.
+the fixes.
+4. Put up a pull request for merging this branch into master and go through the
+normal pull request review process.
   - Merge conflict resolution can be tricky; as a reviewer, please be extra
-    attentive to these PRs and take a look the latest commit, which will
-    contain the conflict resolutions.
+    attentive to these pull requests and take a look the latest commit, which
+    will contain the conflict resolutions.
 
-The above is relevant for any merge into a branch you're sharing with another developer(s) or where there is some reasonable chance that your attempted merge conflict resolution would break the code. If the merge conflicts are minor *and* there is no reasonable chance you would incorrectly resolve the merge conflict, then you may simply resolve the merge conflict on your own. (For example, if the merge conflict is just a conflict of dates at the top of `db/schema.rb`, then just choose the more recent date; there is no need for the above process in such a case.)
+The above is relevant for any merge into a branch you're sharing with another
+developer(s) or where there is some reasonable chance that your attempted merge
+conflict resolution would break the code. If the merge conflicts are minor *and*
+there is no reasonable chance you would incorrectly resolve the merge conflict,
+then you may simply resolve the merge conflict on your own. (For example, if the
+merge conflict is just a conflict of dates at the top of `db/schema.rb`, then
+just choose the more recent date; there is no need for the above process in such
+a case.)

--- a/code/git/Style.md
+++ b/code/git/Style.md
@@ -10,5 +10,5 @@
 - Except for minor changes, give each a commit message that has a title AND a
   body, where you explain why the change was necessary and what your approach
   was (unless self-explanatory from the code).
-- Add a link to the Pivotal ticket somewhere in the PR description.
-- Add any relevant labels to your PR.
+- Add a link to the Pivotal ticket somewhere in the pull request description.
+- Add any relevant labels to your pull request.

--- a/process/Code-Review/Adding-Dependencies.md
+++ b/process/Code-Review/Adding-Dependencies.md
@@ -6,8 +6,8 @@
 
 When adding dependencies, we should consider downstream effects. It should be in
 a separate commit, with a message that addresses as much of the below as
-possible and be reviewed by **two** reviewers. Ensure that you label the PR
-`dependency` to make it easier to find.
+possible and be reviewed by **two** reviewers. Ensure that you label the pull
+request `dependency` to make it easier to find.
 
 #### Community Support
 

--- a/process/Code-Review/README.md
+++ b/process/Code-Review/README.md
@@ -9,38 +9,38 @@ GitHub. For general Git guidelines and practices, see
 
 ### General
 
-- All PRs must satisfy the following requirements:
+- All pull requests must satisfy the following requirements:
     - An approved review
     - Passing on Solano
     - Passing on Code Climate
 - If the author feels either of the automated analysis failures are
-  illegitimate, they should highlight that in a comment on the PR.
+  illegitimate, they should highlight that in a comment on the pull request.
     - Code Climate infractions can be ignored individually or the level of the
-      entire PR.
+      entire pull request.
     - A failing build on Solano will require administrator override to merge.
       All Tech Leads are GitHub admins and will have the power to do so.
-- Don't leave PRs open and inactive for more than 2 business days.
-- Don't merge someone else's PR without their approval.
-- master merge PRs to feature branches do not require review
-- Keep "PR fix" changes in separate commits for ease of review.
-- PRs should include tests if possible, but whether to practice strict TDD
-  (whether to write the tests before or after the code) is up to the author.
-- If your PR is waiting on something other than code review, close it and reopen
-  it when it's ready for code review or to be merged.
+- Don't leave pull requests open and inactive for more than 2 business days.
+- Don't merge someone else's pull request without their approval.
+- master merge pull requests to feature branches do not require review
+- Keep "pull request fix" changes in separate commits for ease of review.
+- pull requests should include tests if possible, but whether to practice strict
+  TDD (whether to write the tests before or after the code) is up to the author.
+- If your pull request is waiting on something other than code review, close it
+  and reopen it when it's ready for code review or to be merged.
 - Code review is a tremendous learning opportunity. If someone shows you
   something new, call it out and thank them!
 - Similarly, if there is something in the code that is especially well done or
   will improve things for the rest of the team, point it out to the author.
-- When commenting on a PR, distinguish between blocking and non-blocking comments
-  if it's unclear.
+- When commenting on a pull request, distinguish between blocking and
+  non-blocking comments if it's unclear.
 
 ### The Review
 
 Code review is not to make sure something works; it is to make sure it is
 workable going forward. Acceptance testing should have been handled previously.
 It is, however, reasonable and expected that the reviewer will make sure the
-author has automated tests covering the functionality added, and that they
-have verified that the feature works.
+author has automated tests covering the functionality added, and that they have
+verified that the feature works.
 
 As a reviewer, begin from the standpoint that the code in front of you works.
 If something about the author's design, implementation, or style confuses you,
@@ -51,8 +51,8 @@ someone will be reading this code before it is committed. It is a special time
 because it will be fresh in the author's head, and thus are very well-suited to
 field questions from the reviewer. Code review is a partnership between author
 and reviewer to make sure that going forward, this code is clear and usable for
-the next time someone has to touch it when the details have become fuzzy from the
-fog of time.
+the next time someone has to touch it when the details have become fuzzy from
+the fog of time.
 
 As a reviewer, if you have worries about the code in its current state, seek to
 back those up with something other than your gut feeling. Use documentation,
@@ -66,8 +66,8 @@ covered in the style guide.
 ### Assigning Reviewers
 
 - Use Github's "Assign Reviewer" feature to call out specific engineers who
-  would be most helpful in reviewing a given PR
-- If you need someone to review a PR, try to ask someone on your team before
+  would be most helpful in reviewing a given pull request
+- If you need someone to review a pull request, try to ask someone on your team before
   going to others.
 
 ### Adding Dependencies

--- a/process/Learning-Time.md
+++ b/process/Learning-Time.md
@@ -19,9 +19,9 @@ job while building features or maintaining existing code.
 
 ## How
 - Example uses:
-    - Test case / proof of concept PRs
+    - Test case / proof of concept pull requests
     - Upcase / Egghead.io tutorials/course, etc.
-    - Refactor PRs
+    - Refactor pull requests
     - Something totally different that helps the team
 - Defer to tech lead / product manager if something urgent needs to be addressed
   instead

--- a/process/Settings.md
+++ b/process/Settings.md
@@ -20,8 +20,9 @@ the [Settings Repo](https://github.com/coverhound/settings-files).
    `[project-name]/staging/[settings-file-name].yml`
 4. Create a ticket in the Pivotal devops project to update the production
    settings
-5. Once the PRs to the settings repo have been merged and the devops ticket has
-   been completed, code that depends on the new settings can be safely released.
+5. Once the pull requests to the settings repo have been merged and the devops
+   ticket has been completed, code that depends on the new settings can be
+   safely released.
 
 ## Local Settings
 


### PR DESCRIPTION
While "PR" is pretty a common way to refer to a pull request, we can
pretty easily be clear about this.