### PR TITLE
Add summary for non-engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ These agreements fall largely into three categories:
   + [Meetings](./people/Meetings.md)
   + [Onboarding](./people/Onboarding.md)
   + [Teamwork](./people/Teamwork/README.md)
+    + [Conflict](./people/Teamwork/Conflict.md)
 
 + [Process](./process/README.md)
   + [Code Review](./process/Code-Review/README.md)
+    + [Adding Dependencies](./process/Code-Review/Adding-Dependencies.md)
   + [Issue Tracking](./process/Issue-Tracking.md)
   + [Learning Time](./process/Learning-Time.md)
   + [Settings](./process/Settings.md)
@@ -32,5 +34,13 @@ These agreements fall largely into three categories:
 + [Technical Guidelines and Style](./code/README.md)
   + [CSS](./code/css/README.md)
   + [Git](./code/git/README.md)
+      + [Style](./code/git/Style.md)
+      + [Commit Messages](./code/git/Commit-Messages.md)
+      + [Branches](./code/git/Branches.md)
+      + [Merging](./code/git/Merging.md)
+    + [Javascript](./javascript/README.md)
   + [Javascript](./code/javascript/README.md)
   + [Ruby](./code/ruby/README.md)
+
+If you're not an engineer but have team members who are, view a summary of the
+information most relevant to you [here](./Working-With-Engineers.md).

--- a/Working-With-Engineers.md
+++ b/Working-With-Engineers.md
@@ -1,0 +1,42 @@
+# Working With CoverHound Engineers:
+## What to know about our working agreements
+
+### [Core Hours:](./people/Communication.md) 10:30AM – 3:30PM
+
+Engineers are expected to be available for communication through Slack, phone,
+or in person, and able to respond promptly (barring meetings) during these
+corehours. It is up to each individual engineer to determine what hours outside
+of those will make up the rest of their day.
+
+### [Slack and Day-to-Day Communication](./people/Communication.md)
+
+Please err on the side of messaging someone in Slack before approaching them in
+person. Engineering often requires deep thinking; interruptions and switching
+context can be a big setback.
+
+### [Meetings](./people/Meetings.md)
+
+- If the team has an in-person standup, it's important to be there and missing
+  it should be an exception. Post your update in Slack if you can't be there.
+- Standup updates follow conventional "agile" format: what you did yesterday,
+  what you're doing today, and whether you have any blockers.
+- Don't get into in-depth discussions in the standup while there are still people
+  waiting to give their updates.
+- At in-team retrospectives, teams discuss the past cycle--what went well, what
+  could go better, as well as any of the things mentioned for Engineering
+  Retrospectives.
+
+### [Issue Tracking](./process/Issue-Tracking.md)
+
+No summary on this one! Please read [the whole document](./process/Issue-Tracking.md)
+about the cycle, using Pivotal, stories, issues, and bugs.
+
+### [Learning Time](./process/Learning-Time.md)
+
+Every other Friday afternoon, following a cycle's engineering retro, is 
+"learning" time for engineers. This is explicit time invested in developing
+their skills or working on something interesting that is of value to the team,
+such as a proof of concept refactor or spiking on a new technology or library
+we might want to use. Engineers should only be pulled away from learning time
+for critical production bugs or to meet external deadlines that wouldn't
+otherwise be met.

--- a/code/README.md
+++ b/code/README.md
@@ -2,5 +2,9 @@
 
 + [CSS](./css/README.md)
 + [Git](./git/README.md)
+  + [Style](./git/Style.md)
+  + [Commit Messages](./git/Commit-Messages.md)
+  + [Branches](./git/Branches.md)
+  + [Merging](./git/Merging.md)
 + [Javascript](./javascript/README.md)
 + [Ruby](./ruby/README.md)

--- a/process/Code-Review/README.md
+++ b/process/Code-Review/README.md
@@ -1,5 +1,5 @@
 [Main](../../README.md) >
-[Process](../README.md) >
+[Process](../README.md)
 
 # Code Review
 

--- a/process/Issue-Tracking.md
+++ b/process/Issue-Tracking.md
@@ -35,7 +35,9 @@
   sense," the next action is not for them to seek to understand it, but rather
   to talk to the story owner. The story owner should clarify the requirements
   in the story.
-- A bug report is not valid and workable without steps to reproduce.
+- All efforts should be made to reproduce a bug before making a report. _With
+  some exceptions,_ a bug report is not valid and workable without steps to
+  reproduce.
 - A story is not valid and workable without acceptance criteria.
 - If a spec completely changes from the original direction of the story after
   development has already begun/completed, a separate ticket should be created

--- a/process/README.md
+++ b/process/README.md
@@ -3,6 +3,7 @@
 # Process
 
 + [Code Review](./Code-Review/README.md)
+  + [Adding Dependencies](./Code-Review/Adding-Dependencies.md)
 + [Issue Tracking](./Issue-Tracking.md)
 + [Learning Time](./Learning-Time.md)
 + [Settings](./Settings.md)


### PR DESCRIPTION
Many of our working agreements also affect our team members who aren't
engineers and it's important that we give them access to this information
so that they know things like what we expect from an issue and why we're
learning instead of working on a ticket on a Friday afternoon. I added
a page with a summary of the most relevant information and links for
those team members so we can ensure we're all on the same page without
expecting them to sift through content they don't need to know.

Additionally, I added some links to child pages in the table of contents
lists so they're easier to find.